### PR TITLE
Simplify project setup by removing Redis Cluster

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,36 +6,15 @@
 
 ### Running Services
 
-The system can run in two modes: single Redis instance (development) or Redis Cluster (production).
-
-#### Development Mode (Single Redis Instance)
+Start all services with:
 
 ```sh
-docker compose --profile single up -d
+docker compose up -d
 ```
 
 This will start:
 
-- Single Redis server
-- Web application (FastAPI)
-- Scheduler service
-- Controller service
-
-#### Production Mode (Redis Cluster)
-
-```sh
-# Set environment variables for cluster mode
-export REDIS_CLUSTER_MODE=true
-export REDIS_SERVICE=redis-cluster
-export REDIS_HOST=redis-cluster
-
-# Start the services with cluster profile
-docker compose --profile cluster up -d
-```
-
-This will start:
-
-- Redis Cluster (3 masters + 3 replicas)
+- Redis server
 - Web application (FastAPI)
 - Scheduler service
 - Controller service
@@ -63,13 +42,7 @@ Open your browser at http://localhost:8000/
 
 The system can be configured using environment variables:
 
-- `REDIS_CLUSTER_MODE`: Set to "true" for cluster mode, "false" for single instance
-- `REDIS_HOST`: Redis host (defaults to "redis" for single instance, "redis-cluster" for cluster mode)
+- `REDIS_HOST`: Redis host (defaults to "redis)
 - `REDIS_PORT`: Redis port (defaults to 6379)
 - `REDIS_PASSWORD`: Redis password (optional)
-
-### Scaling Considerations
-
-- In single instance mode, all Redis operations go to one server
-- In cluster mode, data is automatically sharded across multiple nodes
-- The application code handles both modes transparently through the Redis adapter
+- `REDIS_DB`: Redis database number (defaults to 0)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,58 +1,12 @@
 version: "3.9"
 
 services:
-  # Redis single node (default for development)
   redis:
     image: redis:7.2-alpine
-    ports:
-      - "6379:6379"
     volumes:
       - redis-data:/data
-      - ./redis.conf:/usr/local/etc/redis/redis.conf
-    command: redis-server /usr/local/etc/redis/redis.conf
-    profiles:
-      - single
-    networks:
-      - redis-cluster-net
-
-  # Redis cluster nodes (for production)
-  redis-cluster:
-    image: redis:7.2
-    networks:
-      - redis-cluster-net
-    volumes:
-      - redis-cluster-data:/data
-    command: redis-server --port 6379 --cluster-enabled yes --cluster-config-file nodes.conf --cluster-node-timeout 5000 --appendonly yes
-    profiles:
-      - cluster
-    deploy:
-      replicas: 6 # 3 masters + 3 replicas
     ports:
-      - "6379-6384:6379" # Map each node to a different host port
-      - "16379-16384:16379" # Cluster bus ports
-    environment:
-      - REDIS_CLUSTER_ANNOUNCE_IP=redis-cluster
-
-  redis-cluster-init:
-    image: redis:7.2
-    networks:
-      - redis-cluster-net
-    depends_on:
-      - redis-cluster
-    command: >
-      /bin/sh -c "
-        sleep 10;
-        echo yes | redis-cli --cluster create
-          redis-cluster_1:6379
-          redis-cluster_2:6379
-          redis-cluster_3:6379
-          redis-cluster_4:6379
-          redis-cluster_5:6379
-          redis-cluster_6:6379
-          --cluster-replicas 1
-          --cluster-yes"
-    profiles:
-      - cluster
+      - "6379:6379"
 
   webapp:
     build:
@@ -63,14 +17,11 @@ services:
     volumes:
       - ./src:/app/src
     environment:
-      - REDIS_HOST=${REDIS_HOST:-redis}
-      - REDIS_PORT=${REDIS_PORT:-6379}
-      - REDIS_CLUSTER_MODE=${REDIS_CLUSTER_MODE:-false}
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
       - PYTHONUNBUFFERED=1
     depends_on:
-      - ${REDIS_SERVICE:-redis}
-    networks:
-      - redis-cluster-net
+      - redis
     command: uvicorn src.app.main:app --host 0.0.0.0 --port 8000 --reload --reload-dir /app/src
 
   scheduler:
@@ -80,14 +31,11 @@ services:
     volumes:
       - ./src:/app/src
     environment:
-      - REDIS_HOST=${REDIS_HOST:-redis}
-      - REDIS_PORT=${REDIS_PORT:-6379}
-      - REDIS_CLUSTER_MODE=${REDIS_CLUSTER_MODE:-false}
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
       - PYTHONUNBUFFERED=1
     depends_on:
-      - ${REDIS_SERVICE:-redis}
-    networks:
-      - redis-cluster-net
+      - redis
     command: watchmedo auto-restart --directory=/app/src --pattern=*.py --recursive -- python -m src.scheduler.main
 
   controller:
@@ -97,20 +45,12 @@ services:
     volumes:
       - ./src:/app/src
     environment:
-      - REDIS_HOST=${REDIS_HOST:-redis}
-      - REDIS_PORT=${REDIS_PORT:-6379}
-      - REDIS_CLUSTER_MODE=${REDIS_CLUSTER_MODE:-false}
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
       - PYTHONUNBUFFERED=1
     depends_on:
-      - ${REDIS_SERVICE:-redis}
-    networks:
-      - redis-cluster-net
+      - redis
     command: watchmedo auto-restart --directory=/app/src --pattern=*.py --recursive -- python -m src.controller.main
 
 volumes:
   redis-data:
-  redis-cluster-data:
-
-networks:
-  redis-cluster-net:
-    driver: bridge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "redis>=5.2.1",
     "structlog>=25.2.0",
     "uvicorn>=0.34.1",
+    "watchdog>=2.3.1",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
This commit simplifies the project by removing the Redis Cluster configuration and focusing on a single Redis instance setup. This streamlines the development and deployment process.

The following changes are included:

- Updated docker-compose.yml to remove Redis Cluster services and hardcode Redis connection details.
- Simplified INSTALL.MD to reflect the single Redis instance setup.
- Added watchdog to pyproject.toml for file watching.