### PR TITLE
fix(redis): Use env vars for all Redis client connections

### DIFF
--- a/src/libs/cache/backends/redis.py
+++ b/src/libs/cache/backends/redis.py
@@ -2,6 +2,7 @@
 Redis cache backend implementation.
 """
 
+import os
 import json
 import logging
 from typing import Any, Dict, List, Optional, TypeVar
@@ -23,8 +24,8 @@ class RedisBackend(BaseCacheBackend):
 
     def __init__(
         self,
-        host: str = "localhost",
-        port: int = 6379,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
         db: int = 0,
         password: Optional[str] = None,
         socket_timeout: Optional[float] = 5.0,
@@ -50,8 +51,8 @@ class RedisBackend(BaseCacheBackend):
         """
         self._client: Optional[Redis] = None
         self._client_params = {
-            "host": host,
-            "port": port,
+            "host": host or os.environ.get("REDIS_HOST", "localhost"),
+            "port": port or int(os.environ.get("REDIS_PORT", 6379)),
             "db": db,
             "password": password,
             "socket_timeout": socket_timeout,
@@ -59,6 +60,7 @@ class RedisBackend(BaseCacheBackend):
             "socket_keepalive": socket_keepalive,
             "socket_keepalive_options": socket_keepalive_options or {},
             "max_connections": max_connections,
+            "decode_responses": True,
             **kwargs,
         }
 

--- a/src/libs/cache/config.py
+++ b/src/libs/cache/config.py
@@ -7,10 +7,14 @@ with support for environment variable overrides.
 import os
 from typing import Dict, Any, Optional
 
+# Get Redis host and port from environment variables
+REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
+REDIS_PORT = int(os.environ.get("REDIS_PORT", 6379))
+
 # Default cache settings
 DEFAULT_CACHE_SETTINGS = {
     "BACKEND": "redis",
-    "LOCATION": "redis://localhost:6379/0",
+    "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/0",
     "OPTIONS": {
         "socket_timeout": 5.0,
         "socket_connect_timeout": 5.0,
@@ -104,8 +108,8 @@ def get_redis_params(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     
     # Fall back to individual parameters
     params = {
-        "host": "localhost",
-        "port": 6379,
+        "host": REDIS_HOST,
+        "port": REDIS_PORT,
         "db": 0,
         "password": None,
     }

--- a/src/libs/messaging/event_stream/redis.py
+++ b/src/libs/messaging/event_stream/redis.py
@@ -1,6 +1,7 @@
 """
 Redis Streams implementation of the Event Stream client interface.
 """
+import os
 import json
 from typing import Any, Dict, List, Optional
 
@@ -17,15 +18,22 @@ class RedisStreamClient(EventStreamClient):
 
     def __init__(
         self,
-        host: str = "localhost",
-        port: int = 6379,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
         db: int = 0,
         password: Optional[str] = None,
         **kwargs: Any,
     ):
         """Initialize with Redis connection parameters."""
+        redis_host = host or os.environ.get("REDIS_HOST", "localhost")
+        redis_port = port or int(os.environ.get("REDIS_PORT", 6379))
         self.redis = Redis(
-            host=host, port=port, db=db, password=password, decode_responses=True, **kwargs
+            host=redis_host,
+            port=redis_port,
+            db=db,
+            password=password,
+            decode_responses=True,
+            **kwargs,
         )
 
     async def publish(self, stream: str, data: Dict[str, Any]) -> str:

--- a/src/libs/messaging/pubsub/backends/redis.py
+++ b/src/libs/messaging/pubsub/backends/redis.py
@@ -1,5 +1,6 @@
 """Redis Pub/Sub client implementation."""
 
+import os
 import json
 import logging
 from typing import Any, Dict, Optional, Union
@@ -19,8 +20,8 @@ class RedisPubSubBackend(PubSubClient):
 
     def __init__(
         self,
-        host: str = "localhost",
-        port: int = 6379,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
         db: int = 0,
         password: Optional[str] = None,
         **kwargs: Any,
@@ -30,8 +31,8 @@ class RedisPubSubBackend(PubSubClient):
         self._pubsub: Optional[RedisPubSub] = None
         self._subscriptions = set()
         self._client_params = {
-            "host": host,
-            "port": port,
+            "host": host or os.environ.get("REDIS_HOST", "localhost"),
+            "port": port or int(os.environ.get("REDIS_PORT", 6379)),
             "db": db,
             "password": password,
             "decode_responses": True,


### PR DESCRIPTION
### **Postmortem: Scheduler Redis Connection Failures**

**1. Summary (TL;DR)**

The `scheduler` service was failing to start, entering a crash-loop immediately after being launched with `docker-compose up`. The root cause was that **three** independent Redis client libraries within the application were hardcoded to connect to `localhost:6379` instead of using the `REDIS_HOST` and `REDIS_PORT` environment variables provided by the Docker Compose configuration. This caused a connection failure because, within the Docker network, the `scheduler` container must connect to the Redis container using its service name, `redis`, not `localhost`. The issue was resolved by patching all **three** client libraries to read the host and port from the environment variables.

**2. Timeline of Events**

1.  **Initial State:** The new observability stack (Loki, Promtail, Grafana) was added to `docker-compose.yml`.
2.  **Incident Start:** The user ran `docker-compose up`. All services started except for the `scheduler`, which began logging Redis connection errors and restarting.
3.  **First Investigation:** The logs clearly showed the error `Connect call failed ('127.0.0.1', 6379)`. The initial hypothesis was that the application was not using the `REDIS_HOST` environment variable.
4.  **First Fix Attempt:** The `RedisStreamClient` in `src/libs/messaging/event_stream/redis.py` was identified as a likely culprit and was patched to read connection details from environment variables.
5.  **Incident Persists:** After restarting, the `scheduler` continued to fail with the exact same error message. However, a new log line (`consumer_group_exists`) appeared *before* the crash, indicating the first fix was partially successful but another connection was still failing.
6.  **Second Investigation (Root Cause Discovery):** A deeper analysis revealed that the `scheduler` uses **three** different Redis-backed libraries:
    *   `event_stream` (fixed first).
    *   `cache` (fixed second).
    *   `pubsub` (fixed third, which was the final root cause).
7.  **Resolution:** The `RedisPubSubBackend` class in `src/libs/messaging/pubsub/backends/redis.py` was the last of the three clients to be patched. After this final fix, the `scheduler` started successfully.

**3. Root Cause Analysis**

The failure was a result of two combined factors:

1.  **Hardcoded Configuration:** The primary technical fault was that **three** separate Python classes responsible for connecting to Redis (`RedisStreamClient`, `RedisBackend`, and `RedisPubSubBackend`) had `host="localhost"` as a hardcoded default parameter. This is an anti-pattern in containerized applications, where service discovery relies on hostnames managed by the container network.

2.  **Fragmented Configuration (The Deeper Issue):** The application architecture had no single source of truth for Redis configuration. The `event_stream`, `cache`, and `pubsub` libraries each managed their own separate Redis connections. This architectural flaw is what made the troubleshooting so difficult and iterative. Fixing only one or two of the libraries did not resolve the overall service failure, leading to the "it's still broken" confusion. A robust design would have a single, centralized "Redis Connection Factory" that all three libraries would use.

**4. Action Items & Lessons Learned**

*   **Lesson 1: Centralize Critical Configuration.** For services like databases or message brokers, the connection configuration should be defined in exactly one place in the code.
    *   **Action Item (Long-Term):** Refactor the application to create a single, shared Redis client instance (or a factory function) that is initialized from one central configuration module. The `cache` and `event_stream` libraries should be modified to accept this pre-configured client instead of creating their own. This adheres to the **Don't Repeat Yourself (DRY)** principle.

*   **Lesson 2: Never Hardcode Hostnames in a Containerized World.** All external service locations should be injectable via environment variables.
    *   **Action Item (Short-Term):** Conduct a quick audit of the codebase for other potential hardcoded network locations (e.g., URLs, other hostnames) and replace them with configuration sourced from environment variables.
