### PR TITLE
Fix RedisBackend keys to handle decoded responses

### DIFF
--- a/src/libs/cache/backends/redis.py
+++ b/src/libs/cache/backends/redis.py
@@ -187,7 +187,9 @@ class RedisBackend(BaseCacheBackend):
         """
         try:
             await self._ensure_connected()
-            return [key.decode() for key in await self.client.keys(pattern)]
+            keys = await self.client.keys(pattern)
+            # Redis returns strings when decode_responses=True; handle both
+            return [key.decode() if isinstance(key, bytes) else key for key in keys]
         except RedisConnectionError as e:
             logger.error("Redis keys error: %s", e)
             return []

--- a/tests/cache/test_redis_backend.py
+++ b/tests/cache/test_redis_backend.py
@@ -1,0 +1,17 @@
+import pytest
+import fakeredis
+
+from src.libs.cache.backends.redis import RedisBackend
+
+@pytest.mark.asyncio
+async def test_keys_returns_string_keys():
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    backend = RedisBackend()
+    # Inject fake redis client
+    backend._client = fake
+
+    await backend.set('foo', 'bar')
+    await backend.set('fizz', 'buzz')
+
+    keys = await backend.keys('f*')
+    assert set(keys) == {'foo', 'fizz'}


### PR DESCRIPTION
## Summary
- prevent `RedisBackend.keys` from calling `.decode()` on strings when `decode_responses` is enabled
- add regression test covering `keys` behavior with fakeredis

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a711d3bd28832db044b828d44c3962